### PR TITLE
Fixes organization membership deleted handler type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -67,7 +67,7 @@ export type WebhookRegistrationConfig = {
   onOrganizationInvitationCreated?: HandlerFn<OrganizationInvitationJSON>;
   onOrganizationInvitationRevoked?: HandlerFn<OrganizationInvitationJSON>;
   onOrganizationMembershipCreated?: HandlerFn<OrganizationMembershipJSON>;
-  onOrganizationMembershipDeleted?: HandlerFn<DeletedObjectJSON>;
+  onOrganizationMembershipDeleted?: HandlerFn<OrganizationMembershipJSON>;
   onOrganizationMembershipUpdated?: HandlerFn<OrganizationMembershipJSON>;
   onPermissionCreated?: HandlerFn<PermissionJSON>;
   onPermissionDeleted?: HandlerFn<DeletedObjectJSON>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@types/node':
         specifier: ^20.12.7
         version: 20.17.16
+      typescript:
+        specifier: ^5.7.3
+        version: 5.8.2
 
 packages:
 
@@ -139,6 +142,11 @@ packages:
   type-fest@4.33.0:
     resolution: {integrity: sha512-s6zVrxuyKbbAsSAD5ZPTB77q4YIdRctkTbJ2/Dqlinwz+8ooH2gd+YA7VA6Pa93KML9GockVvoxjZ2vHP+mu8g==}
     engines: {node: '>=16'}
+
+  typescript@5.8.2:
+    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
@@ -283,6 +291,8 @@ snapshots:
   tslib@2.4.1: {}
 
   type-fest@4.33.0: {}
+
+  typescript@5.8.2: {}
 
   undici-types@6.19.8: {}
 


### PR DESCRIPTION
Corrects the type definition for the `onOrganizationMembershipDeleted` webhook handler to use `OrganizationMembershipJSON` instead of `DeletedObjectJSON`.

Updates typescript to the latest version.