### PR TITLE
fix: return 200 response for unused handlers

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -165,8 +165,9 @@ export async function handleWebhooks(config: WebhookRegistrationConfig, req: Req
     return await _handler(evt, handlerMap[evt.type] as HandlerFn<HandlerType>)
   }
 
-  // If we don't have a handler for the event, return a 404
-  return new Response('', { status: 404 })
+  // If we don't have a handler for the event, still return 200 response or else
+  // the Clerk webhook overview shows high error rate
+  return new Response('', { status: 200 })
 }
 
 async function _handler(event: WebhookEvent, callback: Function): Promise<Response> {

--- a/index.ts
+++ b/index.ts
@@ -166,7 +166,7 @@ export async function handleWebhooks(config: WebhookRegistrationConfig, req: Req
   }
 
   // If we don't have a handler for the event, still return 200 response or else
-  // the Clerk webhook overview shows high error rate
+  // the Clerk will keep retrying the event
   return new Response('', { status: 200 })
 }
 


### PR DESCRIPTION
We are using this package but only require one of the handlers currently. For all other events this package currently return a 404 error. This will cause Clerk to repeatedly retry the event, although we are not interested in it. It will also mark a lot of request as failed.

To avoid unnecessary retries this package should not return an error response in case the event isn't handled.